### PR TITLE
Attempting to use unsafe.Slice again

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,59 @@
+package haxmap
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+const (
+	epochs  uintptr = 1 << 12
+	mapSize         = 256
+)
+
+func setupHaxMap() *HashMap[uintptr, uintptr] {
+	m := New[uintptr, uintptr](mapSize)
+	for i := uintptr(0); i < epochs; i++ {
+		m.Set(i, i)
+	}
+	return m
+}
+
+func BenchmarkHaxMapReadsOnly(b *testing.B) {
+	m := setupHaxMap()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for i := uintptr(0); i < epochs; i++ {
+				j, _ := m.Get(i)
+				if j != i {
+					b.Fail()
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkHaxMapReadsWithWrites(b *testing.B) {
+	m := setupHaxMap()
+	var writer uintptr
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		// use 1 thread as writer
+		if atomic.CompareAndSwapUintptr(&writer, 0, 1) {
+			for pb.Next() {
+				for i := uintptr(0); i < epochs; i++ {
+					m.Set(i, i)
+				}
+			}
+		} else {
+			for pb.Next() {
+				for i := uintptr(0); i < epochs; i++ {
+					j, _ := m.Get(i)
+					if j != i {
+						b.Fail()
+					}
+				}
+			}
+		}
+	})
+}

--- a/hash32.go
+++ b/hash32.go
@@ -37,6 +37,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import (
 	"encoding/binary"
 	"math/bits"
+	"reflect"
+	"unsafe"
 )
 
 const (
@@ -109,54 +111,32 @@ func (m *HashMap[K, V]) setDefaultHasher() {
 	switch any(*new(K)).(type) {
 	case int, uint, uintptr:
 		m.hasher = func(key K) uintptr {
-			return defaultSum(*(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&key)),
-				Len:  intSizeBytes,
-			})))
+			return defaultSum(unsafe.Slice((*byte)(unsafe.Pointer(&key)), intSizeBytes))
 		}
 	case int8, uint8:
 		m.hasher = func(key K) uintptr {
-			return defaultSum(*(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&key)),
-				Len:  byteSize,
-			})))
+			return defaultSum(unsafe.Slice((*byte)(unsafe.Pointer(&key)), byteSize))
 		}
 	case int16, uint16:
 		m.hasher = func(key K) uintptr {
-			return defaultSum(*(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&key)),
-				Len:  wordSize,
-			})))
+			return defaultSum(unsafe.Slice((*byte)(unsafe.Pointer(&key)), wordSize))
 		}
 	case int32, uint32, float32:
 		m.hasher = func(key K) uintptr {
-			return defaultSum(*(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&key)),
-				Len:  dwordSize,
-			})))
+			return defaultSum(unsafe.Slice((*byte)(unsafe.Pointer(&key)), dwordSize))
 		}
 	case int64, uint64, float64, complex64:
 		m.hasher = func(key K) uintptr {
-			return defaultSum(*(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&key)),
-				Len:  qwordSize,
-			})))
+			return defaultSum(unsafe.Slice((*byte)(unsafe.Pointer(&key)), qwordSize))
 		}
 	case complex128:
 		m.hasher = func(key K) uintptr {
-			return defaultSum(*(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&key)),
-				Len:  owordSize,
-			})))
+			return defaultSum(unsafe.Slice((*byte)(unsafe.Pointer(&key)), owordSize))
 		}
 	case string:
 		m.hasher = func(key K) uintptr {
 			sh := (*reflect.StringHeader)(unsafe.Pointer(&key))
-			return uintptr(defaultSum(*(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-				Data: sh.Data,
-				Len:  sh.Len,
-				Cap:  sh.Len,
-			}))))
+			return defaultSum(unsafe.Slice((*byte)(unsafe.Pointer(&key)), sh.Len))
 		}
 	}
 }

--- a/hash64.go
+++ b/hash64.go
@@ -133,21 +133,14 @@ func (m *HashMap[K, V]) setDefaultHasher() {
 	case string:
 		m.hasher = func(key K) uintptr {
 			sh := (*reflect.StringHeader)(unsafe.Pointer(&key))
-			return uintptr(defaultSum(*(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-				Data: sh.Data,
-				Len:  sh.Len,
-				Cap:  sh.Len,
-			}))))
+			return uintptr(defaultSum(unsafe.Slice((*byte)(unsafe.Pointer(&key)), sh.Len)))
 		}
 	case int, uint, uintptr:
 		switch intSizeBytes {
 		case 2:
 			// word hasher
 			m.hasher = func(key K) uintptr {
-				b := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-					Data: uintptr(unsafe.Pointer(&key)),
-					Len:  wordSize,
-				}))
+				b := unsafe.Slice((*byte)(unsafe.Pointer(&key)), wordSize)
 
 				var h = prime5 + 2
 
@@ -167,10 +160,7 @@ func (m *HashMap[K, V]) setDefaultHasher() {
 		case 4:
 			// Dword hasher
 			m.hasher = func(key K) uintptr {
-				b := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-					Data: uintptr(unsafe.Pointer(&key)),
-					Len:  dwordSize,
-				}))
+				b := unsafe.Slice((*byte)(unsafe.Pointer(&key)), dwordSize)
 
 				var h = prime5 + 4
 				h ^= (uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24) * prime1
@@ -187,10 +177,7 @@ func (m *HashMap[K, V]) setDefaultHasher() {
 		case 8:
 			// Qword Hash
 			m.hasher = func(key K) uintptr {
-				b := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-					Data: uintptr(unsafe.Pointer(&key)),
-					Len:  qwordSize,
-				}))
+				b := unsafe.Slice((*byte)(unsafe.Pointer(&key)), qwordSize)
 
 				var h = prime5 + 8
 
@@ -216,10 +203,7 @@ func (m *HashMap[K, V]) setDefaultHasher() {
 	case int8, uint8:
 		// byte word hasher
 		m.hasher = func(key K) uintptr {
-			b := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&key)),
-				Len:  byteSize,
-			}))
+			b := unsafe.Slice((*byte)(unsafe.Pointer(&key)), byteSize)
 
 			var h = prime5 + 1
 			h ^= uint64(b[0]) * prime5
@@ -237,10 +221,7 @@ func (m *HashMap[K, V]) setDefaultHasher() {
 	case int16, uint16:
 		// word hasher
 		m.hasher = func(key K) uintptr {
-			b := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&key)),
-				Len:  wordSize,
-			}))
+			b := unsafe.Slice((*byte)(unsafe.Pointer(&key)), wordSize)
 
 			var h = prime5 + 2
 
@@ -260,10 +241,7 @@ func (m *HashMap[K, V]) setDefaultHasher() {
 	case int32, uint32, float32:
 		// Dword hasher
 		m.hasher = func(key K) uintptr {
-			b := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&key)),
-				Len:  dwordSize,
-			}))
+			b := unsafe.Slice((*byte)(unsafe.Pointer(&key)), dwordSize)
 
 			var h = prime5 + 4
 			h ^= (uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24) * prime1
@@ -280,10 +258,7 @@ func (m *HashMap[K, V]) setDefaultHasher() {
 	case int64, uint64, float64, complex64:
 		// Qword hasher
 		m.hasher = func(key K) uintptr {
-			b := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&key)),
-				Len:  qwordSize,
-			}))
+			b := unsafe.Slice((*byte)(unsafe.Pointer(&key)), qwordSize)
 
 			var h = prime5 + 8
 
@@ -308,10 +283,7 @@ func (m *HashMap[K, V]) setDefaultHasher() {
 	case complex128:
 		// Oword hasher
 		m.hasher = func(key K) uintptr {
-			b := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&key)),
-				Len:  owordSize,
-			}))
+			b := unsafe.Slice((*byte)(unsafe.Pointer(&key)), owordSize)
 
 			var h = prime5 + 16
 


### PR DESCRIPTION
In two commits:

 - 80d6073819895a4ee0502c0f21996f16a5afb390
 - 9005c391b9cbdb19f2e83362c336f51a4bdc9807

All usages of unsafe.Slice were removed due to performance reason,
without any proof. In any case, we should prefer correctness over
performance, code should be done right, before thinking about speed.

However, this commit attempts to use unsafe.Slice again, and adding
benchmarks. The result indicates that unsafe.Slice even slightly faster
than incorrect usage of reflect.SliceHeader:

```
name                     old time/op    new time/op    delta
HaxMapReadsOnly-8          10.6µs ± 1%    10.2µs ± 1%  -3.72%  (p=0.000 n=9+10)
HaxMapReadsWithWrites-8    12.6µs ± 2%    12.1µs ± 1%  -4.18%  (p=0.000 n=10+9)

name                     old alloc/op   new alloc/op   delta
HaxMapReadsOnly-8           0.00B          0.00B         ~     (all equal)
HaxMapReadsWithWrites-8    1.04kB ± 3%    1.01kB ± 4%  -2.76%  (p=0.003 n=10+10)

name                     old allocs/op  new allocs/op  delta
HaxMapReadsOnly-8            0.00           0.00         ~     (all equal)
HaxMapReadsWithWrites-8       130 ± 4%       126 ± 4%  -2.93%  (p=0.004 n=10+10)
```

Note that the benchmark is run with perflock to prevent noisy as much as
possible:

```
perflock -governor=70% go1.19 test -run=NONE -bench=. -benchmem -count=10 .
```