### PR TITLE
Support Go 1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The hashing algorithm used was [xxHash](https://github.com/Cyan4973/xxHash) and 
 
 ## Installation
 
-You need Golang [1.19.x](https://go.dev/dl/) or above
+You need Golang [1.18.x](https://go.dev/dl/) or above
 
 ```bash
 $ go get github.com/alphadose/haxmap

--- a/atomics.go
+++ b/atomics.go
@@ -1,26 +1,26 @@
 package haxmap
 
 import (
-	"sync"
 	"sync/atomic"
 	"unsafe"
 )
 
+// noCopy implements sync.Locker so that go vet can trigger
+// warnings when types embedding noCopy are copied.
+type noCopy struct{}
+
 type atomicUint32 struct {
-	// Signal to go vet not to copy this type
-	_ sync.Locker
+	_ noCopy
 	v uint32
 }
 
 type atomicPointer[T any] struct {
-	// Signal to go vet not to copy this type
-	_   sync.Locker
+	_   noCopy
 	ptr unsafe.Pointer
 }
 
 type atomicUintptr struct {
-	// Signal to go vet not to copy this type
-	_   sync.Locker
+	_   noCopy
 	ptr uintptr
 }
 
@@ -46,3 +46,6 @@ func (u *atomicUintptr) Swap(v uintptr) uintptr    { return atomic.SwapUintptr(&
 func (u *atomicUintptr) CompareAndSwap(old, new uintptr) bool {
 	return atomic.CompareAndSwapUintptr(&u.ptr, old, new)
 }
+
+func (c *noCopy) Lock()   {}
+func (c *noCopy) Unlock() {}

--- a/atomics.go
+++ b/atomics.go
@@ -6,7 +6,7 @@ import (
 	"unsafe"
 )
 
-type atomicUInt32 struct {
+type atomicUint32 struct {
 	// Signal to go vet not to copy this type
 	_ sync.Locker
 	v uint32
@@ -24,11 +24,11 @@ type atomicUintptr struct {
 	ptr uintptr
 }
 
-func (u *atomicUInt32) Load() uint32            { return atomic.LoadUint32(&u.v) }
-func (u *atomicUInt32) Store(v uint32)          { atomic.StoreUint32(&u.v, v) }
-func (u *atomicUInt32) Add(delta uint32) uint32 { return atomic.AddUint32(&u.v, delta) }
-func (u *atomicUInt32) Swap(v uint32) uint32    { return atomic.SwapUint32(&u.v, v) }
-func (u *atomicUInt32) CompareAndSwap(old, new uint32) bool {
+func (u *atomicUint32) Load() uint32            { return atomic.LoadUint32(&u.v) }
+func (u *atomicUint32) Store(v uint32)          { atomic.StoreUint32(&u.v, v) }
+func (u *atomicUint32) Add(delta uint32) uint32 { return atomic.AddUint32(&u.v, delta) }
+func (u *atomicUint32) Swap(v uint32) uint32    { return atomic.SwapUint32(&u.v, v) }
+func (u *atomicUint32) CompareAndSwap(old, new uint32) bool {
 	return atomic.CompareAndSwapUint32(&u.v, old, new)
 }
 

--- a/atomics.go
+++ b/atomics.go
@@ -6,6 +6,12 @@ import (
 	"unsafe"
 )
 
+type atomicUInt32 struct {
+	// Signal to go vet not to copy this type
+	_ sync.Locker
+	v uint32
+}
+
 type atomicPointer[T any] struct {
 	// Signal to go vet not to copy this type
 	_   sync.Locker
@@ -16,6 +22,14 @@ type atomicUintptr struct {
 	// Signal to go vet not to copy this type
 	_   sync.Locker
 	ptr uintptr
+}
+
+func (u *atomicUInt32) Load() uint32            { return atomic.LoadUint32(&u.v) }
+func (u *atomicUInt32) Store(v uint32)          { atomic.StoreUint32(&u.v, v) }
+func (u *atomicUInt32) Add(delta uint32) uint32 { return atomic.AddUint32(&u.v, delta) }
+func (u *atomicUInt32) Swap(v uint32) uint32    { return atomic.SwapUint32(&u.v, v) }
+func (u *atomicUInt32) CompareAndSwap(old, new uint32) bool {
+	return atomic.CompareAndSwapUint32(&u.v, old, new)
 }
 
 func (p *atomicPointer[T]) Load() *T     { return (*T)(atomic.LoadPointer(&p.ptr)) }

--- a/atomics.go
+++ b/atomics.go
@@ -1,0 +1,34 @@
+package haxmap
+
+import (
+	"sync"
+	"sync/atomic"
+	"unsafe"
+)
+
+type atomicPointer[T any] struct {
+	// Signal to go vet not to copy this type
+	_   sync.Locker
+	ptr unsafe.Pointer
+}
+
+type atomicUintptr struct {
+	// Signal to go vet not to copy this type
+	_   sync.Locker
+	ptr uintptr
+}
+
+func (p *atomicPointer[T]) Load() *T     { return (*T)(atomic.LoadPointer(&p.ptr)) }
+func (p *atomicPointer[T]) Store(v *T)   { atomic.StorePointer(&p.ptr, unsafe.Pointer(v)) }
+func (p *atomicPointer[T]) Swap(v *T) *T { return (*T)(atomic.SwapPointer(&p.ptr, unsafe.Pointer(v))) }
+func (p *atomicPointer[T]) CompareAndSwap(old, new *T) bool {
+	return atomic.CompareAndSwapPointer(&p.ptr, unsafe.Pointer(old), unsafe.Pointer(new))
+}
+
+func (u *atomicUintptr) Load() uintptr             { return atomic.LoadUintptr(&u.ptr) }
+func (u *atomicUintptr) Store(v uintptr)           { atomic.StoreUintptr(&u.ptr, v) }
+func (u *atomicUintptr) Add(delta uintptr) uintptr { return atomic.AddUintptr(&u.ptr, delta) }
+func (u *atomicUintptr) Swap(v uintptr) uintptr    { return atomic.SwapUintptr(&u.ptr, v) }
+func (u *atomicUintptr) CompareAndSwap(old, new uintptr) bool {
+	return atomic.CompareAndSwapUintptr(&u.ptr, old, new)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/alphadose/haxmap
 
-go 1.19
+go 1.18

--- a/list.go
+++ b/list.go
@@ -1,9 +1,5 @@
 package haxmap
 
-import (
-	"sync/atomic"
-)
-
 // mark a node for being deleted, also used as list_head
 // the search() function skips nodes with `keyHash = marked`
 const marked = ^uintptr(0)
@@ -13,7 +9,7 @@ const marked = ^uintptr(0)
 
 // newListHead returns the new head of any list
 func newListHead[K hashable, V any]() *element[K, V] {
-	e := &element[K, V]{marked, *new(K), atomic.Pointer[element[K, V]]{}, atomic.Pointer[V]{}}
+	e := &element[K, V]{marked, *new(K), atomicPointer[element[K, V]]{}, atomicPointer[V]{}}
 	e.nextPtr.Store(nil)
 	e.value.Store(new(V))
 	return e
@@ -24,8 +20,8 @@ type element[K hashable, V any] struct {
 	keyHash uintptr
 	key     K
 	// The next element in the list. If this pointer has the marked flag set it means THIS element, not the next one, is deleted.
-	nextPtr atomic.Pointer[element[K, V]]
-	value   atomic.Pointer[V]
+	nextPtr atomicPointer[element[K, V]]
+	value   atomicPointer[V]
 }
 
 // next returns the next element

--- a/map.go
+++ b/map.go
@@ -43,7 +43,7 @@ type (
 		listHead *element[K, V] // Harris lock-free list of elements in ascending order of hash
 		hasher   func(K) uintptr
 		metadata atomicPointer[metadata[K, V]] // atomic.Pointer for safe access even during resizing
-		resizing atomicUInt32
+		resizing atomicUint32
 		numItems atomicUintptr
 	}
 )


### PR DESCRIPTION
Small changes that recreate types introduced in Go 1.19's `atomic` so that this module may support Go 1.18.