### PR TITLE
Added unsafe.Pointer as a key type

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -241,7 +241,7 @@ func (m *Map[K, V]) setDefaultHasher() {
 
 			return uintptr(h)
 		}
-	case int, uint, uintptr:
+	case int, uint, uintptr, unsafe.Pointer:
 		switch intSizeBytes {
 		case 2:
 			// word hasher

--- a/map.go
+++ b/map.go
@@ -26,9 +26,8 @@ const (
 )
 
 type (
-	// allowed map key types constraint
 	hashable interface {
-		int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64 | uintptr | float32 | float64 | string | complex64 | complex128
+		int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64 | uintptr | float32 | float64 | string | complex64 | complex128 | unsafe.Pointer
 	}
 
 	// metadata of the hashmap


### PR DESCRIPTION
Gives the ability to store a pointer in the map, which the garbage collector will keep alive